### PR TITLE
[PERF] Reduce jank when launching tabs

### DIFF
--- a/android-app/app/src/main/java/arun/com/chromer/browsing/amp/AmpResolverActivity.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/amp/AmpResolverActivity.kt
@@ -28,7 +28,7 @@ import arun.com.chromer.R
 import arun.com.chromer.browsing.BrowsingActivity
 import arun.com.chromer.data.website.model.Website
 import arun.com.chromer.di.activity.ActivityComponent
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import com.afollestad.materialdialogs.MaterialDialog
 import rx.subscriptions.CompositeSubscription
 import javax.inject.Inject
@@ -37,7 +37,7 @@ class AmpResolverActivity : BrowsingActivity() {
     private var ampResolverDialog: AmpResolverDialog? = null
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android-app/app/src/main/java/arun/com/chromer/browsing/article/ArticleActivity.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/article/ArticleActivity.kt
@@ -50,7 +50,7 @@ import arun.com.chromer.extenstions.setMenuBackgroundColor
 import arun.com.chromer.extenstions.show
 import arun.com.chromer.extenstions.watch
 import arun.com.chromer.settings.Preferences.*
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.ColorUtil
 import arun.com.chromer.util.Utils
 import butterknife.OnClick
@@ -80,7 +80,7 @@ class ArticleActivity : BrowsingActivity() {
     private var articleScrollListener: ArticleScrollListener? = null
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
     @Inject
     lateinit var menuDelegate: MenuDelegate
     @Inject
@@ -184,7 +184,13 @@ class ArticleActivity : BrowsingActivity() {
         // rendering tab.
         finish()
         Toast.makeText(this, R.string.article_loading_failed, Toast.LENGTH_SHORT).show()
-        tabsManager.openBrowsingTab(this, Website(intent.dataString!!), true, false, tabsManager.browsingActivitiesName)
+        tabsManager.openBrowsingTab(
+                this,
+                Website(intent.dataString!!),
+                smart = true,
+                fromNewTab = false,
+                activityNames = TabsManager.browsingActivitiesName
+        )
     }
 
     private fun onArticleLoaded(webArticle: WebArticle) {

--- a/android-app/app/src/main/java/arun/com/chromer/browsing/browserintercept/BrowserInterceptActivity.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/browserintercept/BrowserInterceptActivity.kt
@@ -26,14 +26,14 @@ import android.widget.Toast.LENGTH_SHORT
 import arun.com.chromer.R
 import arun.com.chromer.di.activity.ActivityComponent
 import arun.com.chromer.shared.base.activity.BaseActivity
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.SafeIntent
 import javax.inject.Inject
 
 @SuppressLint("GoogleAppIndexingApiWarning")
 class BrowserInterceptActivity : BaseActivity() {
     @Inject
-    lateinit var defaultTabsManager: DefaultTabsManager
+    lateinit var defaultTabsManager: TabsManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android-app/app/src/main/java/arun/com/chromer/browsing/customtabs/bottombar/BottomBarReceiver.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/customtabs/bottombar/BottomBarReceiver.kt
@@ -28,14 +28,14 @@ import arun.com.chromer.R
 import arun.com.chromer.browsing.customtabs.CustomTabActivity
 import arun.com.chromer.data.website.model.Website
 import arun.com.chromer.shared.Constants
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.Utils
 import timber.log.Timber
 import javax.inject.Inject
 
 class BottomBarReceiver : BroadcastReceiver() {
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun onReceive(context: Context, intent: Intent) {
         (context.applicationContext as Chromer).appComponent.inject(this)

--- a/android-app/app/src/main/java/arun/com/chromer/browsing/customtabs/callbacks/MinimizeBroadcastReceiver.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/customtabs/callbacks/MinimizeBroadcastReceiver.kt
@@ -25,14 +25,14 @@ import android.content.Intent
 import arun.com.chromer.Chromer
 import arun.com.chromer.browsing.customtabs.CustomTabActivity
 import arun.com.chromer.shared.Constants
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import timber.log.Timber
 import javax.inject.Inject
 
 class MinimizeBroadcastReceiver : BroadcastReceiver() {
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun onReceive(context: Context, intent: Intent) {
         (context.applicationContext as Chromer).appComponent.inject(this)

--- a/android-app/app/src/main/java/arun/com/chromer/browsing/menu/MenuDelegate.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/menu/MenuDelegate.kt
@@ -47,7 +47,7 @@ import arun.com.chromer.history.HistoryActivity
 import arun.com.chromer.settings.Preferences
 import arun.com.chromer.settings.Preferences.*
 import arun.com.chromer.shortcuts.HomeScreenShortcutCreatorActivity
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.Utils
 import arun.com.chromer.util.Utils.isPackageInstalled
 import arun.com.chromer.util.Utils.shareText
@@ -64,7 +64,7 @@ import javax.inject.Inject
 @PerActivity
 class MenuDelegate @Inject constructor(
         val activity: Activity,
-        val tabsManager: DefaultTabsManager,
+        val tabsManager: TabsManager,
         val preferences: Preferences
 ) {
     /**

--- a/android-app/app/src/main/java/arun/com/chromer/browsing/newtab/NewTabDialogActivity.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/newtab/NewTabDialogActivity.kt
@@ -30,7 +30,7 @@ import arun.com.chromer.data.website.model.Website
 import arun.com.chromer.di.activity.ActivityComponent
 import arun.com.chromer.extenstions.showKeyboard
 import arun.com.chromer.shared.base.activity.BaseActivity
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import butterknife.ButterKnife
 import butterknife.Unbinder
 import com.afollestad.materialdialogs.MaterialDialog
@@ -47,7 +47,7 @@ class NewTabDialogActivity : BaseActivity() {
     private var newTabDialog: NewTabDialog? = null
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android-app/app/src/main/java/arun/com/chromer/browsing/optionspopup/ChromerOptionsActivity.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/optionspopup/ChromerOptionsActivity.kt
@@ -36,7 +36,7 @@ import arun.com.chromer.shared.Constants.EXTRA_KEY_FROM_ARTICLE
 import arun.com.chromer.shared.Constants.EXTRA_KEY_ORIGINAL_URL
 import arun.com.chromer.shared.base.activity.BaseActivity
 import arun.com.chromer.shortcuts.HomeScreenShortcutCreatorActivity
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
 import kotlinx.android.extensions.LayoutContainer
@@ -50,7 +50,7 @@ class ChromerOptionsActivity : BaseActivity() {
     private var fromArticle: Boolean = false
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android-app/app/src/main/java/arun/com/chromer/browsing/shareintercept/ShareInterceptActivity.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/browsing/shareintercept/ShareInterceptActivity.kt
@@ -30,7 +30,7 @@ import arun.com.chromer.data.website.model.Website
 import arun.com.chromer.di.activity.ActivityComponent
 import arun.com.chromer.shared.Constants
 import arun.com.chromer.shared.base.activity.BaseActivity
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.SafeIntent
 import arun.com.chromer.util.Utils
 import javax.inject.Inject
@@ -39,7 +39,7 @@ import javax.inject.Inject
 class ShareInterceptActivity : BaseActivity() {
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     @TargetApi(Build.VERSION_CODES.M)
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android-app/app/src/main/java/arun/com/chromer/di/app/AppComponent.java
+++ b/android-app/app/src/main/java/arun/com/chromer/di/app/AppComponent.java
@@ -33,11 +33,13 @@ import arun.com.chromer.di.activity.ActivityModule;
 import arun.com.chromer.di.service.ServiceComponent;
 import arun.com.chromer.di.service.ServiceModule;
 import arun.com.chromer.tabs.DefaultTabsManager;
+import arun.com.chromer.tabs.TabsModule;
 import dagger.Component;
 
 @Singleton
 @Component(modules = {
         AppModule.class,
+        TabsModule.class,
         DataModule.class,
 })
 public interface AppComponent {

--- a/android-app/app/src/main/java/arun/com/chromer/history/HistoryAdapter.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/history/HistoryAdapter.kt
@@ -32,7 +32,7 @@ import arun.com.chromer.di.scopes.PerFragment
 import arun.com.chromer.extenstions.gone
 import arun.com.chromer.extenstions.inflate
 import arun.com.chromer.extenstions.show
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import butterknife.BindView
 import butterknife.ButterKnife
 import com.bumptech.glide.RequestManager
@@ -45,7 +45,7 @@ import javax.inject.Inject
 class HistoryAdapter
 @Inject
 constructor(
-        private val defaultTabsManager: DefaultTabsManager,
+        private val defaultTabsManager: TabsManager,
         private val requestManager: RequestManager
 ) : PagedListAdapter<Website, HistoryAdapter.HistoryViewHolder>(Website.DIFFER) {
 

--- a/android-app/app/src/main/java/arun/com/chromer/home/HomeActivity.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/home/HomeActivity.kt
@@ -56,7 +56,6 @@ import arun.com.chromer.shared.FabHandler
 import arun.com.chromer.shared.base.Snackable
 import arun.com.chromer.shared.base.activity.BaseActivity
 import arun.com.chromer.shared.behavior.FloatingActionButtonBehavior
-import arun.com.chromer.tabs.DefaultTabsManager
 import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.tabs.ui.TabsFragment
 import arun.com.chromer.util.RxEventBus
@@ -82,13 +81,13 @@ import javax.inject.Inject
 
 class HomeActivity : BaseActivity(), Snackable {
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
     @Inject
     lateinit var rxEventBus: RxEventBus
     @Inject
     lateinit var activeFragmentManagerFactory: ActiveFragmentsManager.Factory
     @Inject
-    lateinit var tabsManger: DefaultTabsManager
+    lateinit var tabsManger: TabsManager
 
     private lateinit var activeFragmentManager: ActiveFragmentsManager
 

--- a/android-app/app/src/main/java/arun/com/chromer/home/fragment/RecentsAdapter.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/home/fragment/RecentsAdapter.kt
@@ -22,12 +22,12 @@ package arun.com.chromer.home.fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
 import arun.com.chromer.R
 import arun.com.chromer.data.website.model.Website
 import arun.com.chromer.di.scopes.PerFragment
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.glide.GlideApp
 import butterknife.ButterKnife
 import kotlinx.android.extensions.LayoutContainer
@@ -41,7 +41,7 @@ import javax.inject.Inject
 @PerFragment
 class RecentsAdapter
 @Inject
-constructor(val tabsManager: DefaultTabsManager) : RecyclerView.Adapter<RecentsAdapter.RecentsViewHolder>() {
+constructor(val tabsManager: TabsManager) : RecyclerView.Adapter<RecentsAdapter.RecentsViewHolder>() {
     private val websites = ArrayList<Website>()
 
     init {
@@ -83,7 +83,7 @@ constructor(val tabsManager: DefaultTabsManager) : RecyclerView.Adapter<RecentsA
     }
 
     class RecentsViewHolder(
-            val tabsManager: DefaultTabsManager,
+            val tabsManager: TabsManager,
             override val containerView: View
     ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
         init {

--- a/android-app/app/src/main/java/arun/com/chromer/intro/fragments/ArticleIntroFragment.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/intro/fragments/ArticleIntroFragment.kt
@@ -25,7 +25,7 @@ import arun.com.chromer.R
 import arun.com.chromer.data.website.model.Website
 import arun.com.chromer.di.fragment.FragmentComponent
 import arun.com.chromer.shared.base.fragment.BaseFragment
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.glide.GlideApp
 import butterknife.OnClick
 import com.github.paolorotolo.appintro.ISlideBackgroundColorHolder
@@ -40,7 +40,7 @@ open class ArticleIntroFragment : BaseFragment(), ISlideBackgroundColorHolder {
     }
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun inject(fragmentComponent: FragmentComponent) = fragmentComponent.inject(this)
     override fun getLayoutRes() = R.layout.fragment_article_intro

--- a/android-app/app/src/main/java/arun/com/chromer/intro/fragments/ProviderSelectionIntroFragment.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/intro/fragments/ProviderSelectionIntroFragment.kt
@@ -26,7 +26,7 @@ import arun.com.chromer.R
 import arun.com.chromer.browsing.providerselection.ProviderSelectionActivity
 import arun.com.chromer.di.fragment.FragmentComponent
 import arun.com.chromer.shared.base.fragment.BaseFragment
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.glide.GlideApp
 import butterknife.OnClick
 import com.github.paolorotolo.appintro.ISlideBackgroundColorHolder
@@ -41,7 +41,7 @@ open class ProviderSelectionIntroFragment : BaseFragment(), ISlideBackgroundColo
     }
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun inject(fragmentComponent: FragmentComponent) = fragmentComponent.inject(this)
     override fun getLayoutRes() = R.layout.fragment_provider_selection_intro

--- a/android-app/app/src/main/java/arun/com/chromer/intro/fragments/SlideOverExplanationFragment.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/intro/fragments/SlideOverExplanationFragment.kt
@@ -27,7 +27,7 @@ import arun.com.chromer.R
 import arun.com.chromer.data.website.model.Website
 import arun.com.chromer.di.fragment.FragmentComponent
 import arun.com.chromer.shared.base.fragment.BaseFragment
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.glide.GlideApp
 import butterknife.OnClick
 import com.github.paolorotolo.appintro.ISlideBackgroundColorHolder
@@ -42,7 +42,7 @@ open class SlideOverExplanationFragment : BaseFragment(), ISlideBackgroundColorH
     }
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun inject(fragmentComponent: FragmentComponent) = fragmentComponent.inject(this)
     override fun getLayoutRes() = R.layout.fragment_slide_over_intro

--- a/android-app/app/src/main/java/arun/com/chromer/intro/fragments/WebHeadsIntroFragment.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/intro/fragments/WebHeadsIntroFragment.kt
@@ -26,7 +26,7 @@ import androidx.core.content.ContextCompat
 import arun.com.chromer.R
 import arun.com.chromer.di.fragment.FragmentComponent
 import arun.com.chromer.shared.base.fragment.BaseFragment
-import arun.com.chromer.tabs.DefaultTabsManager
+import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.glide.GlideApp
 import butterknife.OnClick
 import com.github.paolorotolo.appintro.ISlideBackgroundColorHolder
@@ -41,7 +41,7 @@ open class WebHeadsIntroFragment : BaseFragment(), ISlideBackgroundColorHolder {
     }
 
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
 
     override fun inject(fragmentComponent: FragmentComponent) = fragmentComponent.inject(this)
     override fun getLayoutRes() = R.layout.fragment_web_heads_intro

--- a/android-app/app/src/main/java/arun/com/chromer/tabs/DefaultTabsManager.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/tabs/DefaultTabsManager.kt
@@ -80,17 +80,6 @@ constructor(
 
     private val subs = CompositeSubscription()
 
-    private val allBrowsingActivitiesName = arrayListOf<String>(
-            CustomTabActivity::class.java.name,
-            ArticleActivity::class.java.name,
-            WebViewActivity::class.java.name
-    )
-
-    val browsingActivitiesName = arrayListOf<String>(
-            CustomTabActivity::class.java.name,
-            WebViewActivity::class.java.name
-    )
-
     override fun openUrl(
             context: Context,
             website: Website,
@@ -212,7 +201,7 @@ constructor(
                             val urlMatches = url != null && website.matches(url)
 
                             val taskComponentMatches = activityNames?.contains(componentClassName)
-                                    ?: allBrowsingActivitiesName.contains(componentClassName)
+                                    ?: TabsManager.allBrowsingActivitiesName.contains(componentClassName)
 
                             if (taskComponentMatches && urlMatches) {
                                 foundAction(task)

--- a/android-app/app/src/main/java/arun/com/chromer/tabs/DefaultTabsManager.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/tabs/DefaultTabsManager.kt
@@ -57,7 +57,10 @@ import arun.com.chromer.util.Utils.openDrawOverlaySettings
 import arun.com.chromer.webheads.WebHeadService
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.Theme
+import rx.Completable
 import rx.Single
+import rx.schedulers.Schedulers
+import rx.subscriptions.CompositeSubscription
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -74,6 +77,8 @@ constructor(
         private val articlePreloader: ArticlePreloader,
         private val rxEventBus: RxEventBus
 ) : TabsManager {
+
+    private val subs = CompositeSubscription()
 
     private val allBrowsingActivitiesName = arrayListOf<String>(
             CustomTabActivity::class.java.name,
@@ -94,6 +99,31 @@ constructor(
             fromNewTab: Boolean,
             fromAmp: Boolean,
             incognito: Boolean
+    ) {
+        Completable
+                .fromAction {
+                    openUrlInternal(
+                            fromApp,
+                            fromWebHeads,
+                            context,
+                            website,
+                            fromAmp,
+                            incognito,
+                            fromNewTab
+                    )
+                }.subscribeOn(Schedulers.computation())
+                .subscribe()
+                .let(subs::add)
+    }
+
+    private fun openUrlInternal(
+            fromApp: Boolean,
+            fromWebHeads: Boolean,
+            context: Context,
+            website: Website,
+            fromAmp: Boolean,
+            incognito: Boolean,
+            fromNewTab: Boolean
     ) {
         // Clear non browsing activities if it was external intent.
         if (!fromApp) {

--- a/android-app/app/src/main/java/arun/com/chromer/tabs/TabsManager.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/tabs/TabsManager.kt
@@ -32,6 +32,19 @@ import rx.Single
  * Helper class to manage tabs opened by Lynket. Responsible for managing Lynket's task stack.
  */
 interface TabsManager {
+
+    companion object {
+        val allBrowsingActivitiesName = arrayListOf<String>(
+                CustomTabActivity::class.java.name,
+                ArticleActivity::class.java.name,
+                WebViewActivity::class.java.name
+        )
+        val browsingActivitiesName = arrayListOf<String>(
+                CustomTabActivity::class.java.name,
+                WebViewActivity::class.java.name
+        )
+    }
+
     // Event for closing non browsing activity.
     class FinishRoot
 

--- a/android-app/app/src/main/java/arun/com/chromer/tabs/TabsModule.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/tabs/TabsModule.kt
@@ -1,0 +1,11 @@
+package arun.com.chromer.tabs
+
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class TabsModule {
+
+    @Binds
+    abstract fun tabsManager(defaultTabsManager: DefaultTabsManager): TabsManager
+}

--- a/android-app/app/src/main/java/arun/com/chromer/tabs/ui/TabsAdapter.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/tabs/ui/TabsAdapter.kt
@@ -29,7 +29,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import arun.com.chromer.R
 import arun.com.chromer.data.website.model.Website
-import arun.com.chromer.tabs.*
+import arun.com.chromer.tabs.ARTICLE
+import arun.com.chromer.tabs.CUSTOM_TAB
+import arun.com.chromer.tabs.TabsManager
+import arun.com.chromer.tabs.WEB_VIEW
 import arun.com.chromer.util.glide.GlideRequests
 import butterknife.BindView
 import butterknife.ButterKnife
@@ -44,7 +47,7 @@ import rx.subscriptions.CompositeSubscription
 class TabsAdapter
 constructor(
         val glideRequests: GlideRequests,
-        val tabsManager: DefaultTabsManager
+        val tabsManager: TabsManager
 ) : RecyclerView.Adapter<TabsAdapter.TabsViewHolder>() {
 
     private val tabs: ArrayList<TabsManager.Tab> = ArrayList()

--- a/android-app/app/src/main/java/arun/com/chromer/tabs/ui/TabsFragment.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/tabs/ui/TabsFragment.kt
@@ -37,7 +37,6 @@ import arun.com.chromer.extenstions.gone
 import arun.com.chromer.extenstions.show
 import arun.com.chromer.shared.FabHandler
 import arun.com.chromer.shared.base.fragment.BaseFragment
-import arun.com.chromer.tabs.DefaultTabsManager
 import arun.com.chromer.tabs.TabsManager
 import arun.com.chromer.util.glide.GlideApp
 import com.afollestad.materialdialogs.MaterialDialog
@@ -49,7 +48,7 @@ import javax.inject.Inject
  */
 class TabsFragment : BaseFragment(), FabHandler {
     @Inject
-    lateinit var tabsManager: DefaultTabsManager
+    lateinit var tabsManager: TabsManager
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
 

--- a/android-app/app/src/main/java/arun/com/chromer/tabs/ui/TabsViewModel.kt
+++ b/android-app/app/src/main/java/arun/com/chromer/tabs/ui/TabsViewModel.kt
@@ -22,7 +22,6 @@ package arun.com.chromer.tabs.ui
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import arun.com.chromer.data.website.WebsiteRepository
-import arun.com.chromer.tabs.DefaultTabsManager
 import arun.com.chromer.tabs.TabsManager
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
@@ -34,7 +33,7 @@ import javax.inject.Inject
 class TabsViewModel
 @Inject
 constructor(
-        private val tabsManager: DefaultTabsManager,
+        private val tabsManager: TabsManager,
         private val websiteRepository: WebsiteRepository
 ) : ViewModel() {
     val loadingLiveData = MutableLiveData<Boolean>()

--- a/android-app/app/src/main/java/arun/com/chromer/webheads/WebHeadService.java
+++ b/android-app/app/src/main/java/arun/com/chromer/webheads/WebHeadService.java
@@ -68,7 +68,7 @@ import arun.com.chromer.data.website.model.Website;
 import arun.com.chromer.di.service.ServiceComponent;
 import arun.com.chromer.settings.Preferences;
 import arun.com.chromer.shared.Constants;
-import arun.com.chromer.tabs.DefaultTabsManager;
+import arun.com.chromer.tabs.TabsManager;
 import arun.com.chromer.util.SchedulerProvider;
 import arun.com.chromer.util.Utils;
 import arun.com.chromer.webheads.physics.SpringChain2D;
@@ -164,7 +164,7 @@ public class WebHeadService extends OverlayService implements WebHeadContract,
     WebsiteRepository websiteRepository;
 
     @Inject
-    DefaultTabsManager tabsManager;
+    TabsManager tabsManager;
 
     @Inject
     ArticlePreloader articlePreloader;

--- a/android-app/app/src/main/java/arun/com/chromer/webheads/ui/context/WebHeadContextActivity.java
+++ b/android-app/app/src/main/java/arun/com/chromer/webheads/ui/context/WebHeadContextActivity.java
@@ -48,7 +48,7 @@ import arun.com.chromer.data.website.model.Website;
 import arun.com.chromer.di.activity.ActivityComponent;
 import arun.com.chromer.settings.Preferences;
 import arun.com.chromer.shared.base.activity.BaseActivity;
-import arun.com.chromer.tabs.DefaultTabsManager;
+import arun.com.chromer.tabs.TabsManager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -73,7 +73,7 @@ public class WebHeadContextActivity extends BaseActivity implements WebsiteAdapt
     @BindView(R.id.context_activity_card_view)
     CardView rootCardView;
     @Inject
-    DefaultTabsManager tabsManager;
+    TabsManager tabsManager;
     private WebsiteAdapter websitesAdapter;
 
     @Override

--- a/android-app/app/src/test/java/arun/com/chromer/ChromerRobolectricSuite.kt
+++ b/android-app/app/src/test/java/arun/com/chromer/ChromerRobolectricSuite.kt
@@ -28,6 +28,8 @@ import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import rx.plugins.RxJavaHooks
+import rx.schedulers.Schedulers
 import javax.inject.Inject
 
 
@@ -45,8 +47,16 @@ abstract class ChromerRobolectricSuite {
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
+        setupRxSchedulers()
         testAppComponent = (application as ChromerTestApplication).appComponent as TestAppComponent
         testAppComponent.inject(this)
+    }
+
+
+    private fun setupRxSchedulers() {
+        RxJavaHooks.setOnComputationScheduler { Schedulers.trampoline() }
+        RxJavaHooks.setOnIOScheduler { Schedulers.trampoline() }
+        RxJavaHooks.setOnNewThreadScheduler { Schedulers.trampoline() }
     }
 
     internal fun clearPreferences() {

--- a/android-app/app/src/test/java/arun/com/chromer/di/app/TestAppComponent.java
+++ b/android-app/app/src/test/java/arun/com/chromer/di/app/TestAppComponent.java
@@ -27,11 +27,13 @@ import arun.com.chromer.ChromerRobolectricSuite;
 import arun.com.chromer.data.apps.DefaultAppRepositoryTest;
 import arun.com.chromer.di.data.TestDataModule;
 import arun.com.chromer.tabs.DefaultTabsManagerTest;
+import arun.com.chromer.tabs.TabsModule;
 import dagger.Component;
 
 @Singleton
 @Component(modules = {
         TestAppModule.class,
+        TabsModule.class,
         TestDataModule.class
 })
 public interface TestAppComponent extends AppComponent {

--- a/android-app/app/src/test/java/arun/com/chromer/tabs/DefaultTabsManagerTest.kt
+++ b/android-app/app/src/test/java/arun/com/chromer/tabs/DefaultTabsManagerTest.kt
@@ -28,7 +28,6 @@ import arun.com.chromer.webheads.WebHeadService
 import org.junit.Before
 import org.junit.Test
 import org.robolectric.Robolectric
-import org.robolectric.Shadows
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowApplication
 import javax.inject.Inject
@@ -39,7 +38,7 @@ import javax.inject.Inject
  */
 class DefaultTabsManagerTest : ChromerRobolectricSuite() {
     @Inject
-    lateinit var tabs: DefaultTabsManager
+    lateinit var tabs: TabsManager
 
     private val url = "https://www.example.com"
 


### PR DESCRIPTION
Lynket was doing customization work before launching tabs. This was okay when the customization work was small but I added more stuff, this causes minor jank when a new tab is launched. This PR fixes that by moving the customization work to a background thread.